### PR TITLE
upload frosty logo for og:image attribute

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -6,4 +6,4 @@ KEY="${KEY:-~/.ssh/frosty}"
 cabal run results 2023-2024
 dest="frosty@smart-cactus.org:/var/www/frosty.smart-cactus.org"
 scp -i $KEY scores.html "$dest/index.html"
-scp -i $KEY rankings.js rankings.css "$dest"
+scp -i $KEY rankings.js rankings.css logo.gif "$dest"


### PR DESCRIPTION
the `og:image` metatag references a logo. I changed the upload.sh to ensure the logo gets uploaded to the html content.